### PR TITLE
📑 Use documentElement rather than body

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -1,6 +1,6 @@
 export function getCharacterWidth(string) {
   const span = document.createElement('span');
-  span.style.font = '1rem Times, "Times New Roman", serif';
+  span.style.font = '16px Times, "Times New Roman", serif';
   span.appendChild(document.createTextNode(string));
 
   document.documentElement.appendChild(span);

--- a/src/dom.js
+++ b/src/dom.js
@@ -3,9 +3,9 @@ export function getCharacterWidth(string) {
   span.style.font = '1rem Times, "Times New Roman", serif';
   span.appendChild(document.createTextNode(string));
 
-  document.body.appendChild(span);
+  document.documentElement.appendChild(span);
   const { width } = span.getBoundingClientRect();
-  document.body.removeChild(span);
+  document.documentElement.removeChild(span);
 
   return Math.round(width);
 }


### PR DESCRIPTION
This means DOM tests can run earlier!